### PR TITLE
Previous partial

### DIFF
--- a/lib/Storeit.js
+++ b/lib/Storeit.js
@@ -4,6 +4,7 @@ var Q = require("q");
 var _ = require("underscore");
 var pubit = require("pubit-as-promised");
 var whatsDifferent = require("./utils").whatsDifferent;
+var previously = require("./utils").previously;
 var isObject = require("./utils").isObject;
 var cloneObject = require("./utils").cloneObject;
 var isEqual = require("./utils").isEqual;
@@ -123,17 +124,22 @@ function Storeit(namespace, storageProvider) {
     function setCache(key, value) {
         var results = {};
         if (has(key)) {
-            var partial = value;
+            var previousPartial;
+            var partial;
             var currentValue = getValue(key);
             if (isObject(value) && isObject(currentValue)) {
                 value = _.extend(cloneObject(currentValue), value); // Allow "patching" with partial value.
                 partial = whatsDifferent(currentValue, value);
+                previousPartial = previously(currentValue, partial);
+            } else {
+                partial = value;
+                previousPartial = currentValue;
             }
             if (isEqual(currentValue, value)) {
                 results.action = Action.none;
             } else {
                 cache[key].value = value;
-                publish(EventName.modified, partial, key);
+                publish(EventName.modified, partial, key, previousPartial);
                 results.action = Action.modified;
             }
         } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 "use strict";
+/* global JSON */
 
 var _ = require("underscore");
 
@@ -41,6 +42,21 @@ exports.whatsDifferent = function (template, override) {
     var newProps = newProperties(template, override); // {d:1}
     return _.extend(diff, newProps); // {a:2, d:1}
 };
+
+// We ask the question "what were the previous values of an object"?
+// {a:1, b:1, c:1} {a:2} returns {a:1}
+function previously(currentValue, partial) {
+    var previous = {};
+    Object.keys(partial).forEach(function(key) {
+        if (isObject(currentValue[key])) {
+            previous[key] = previously(currentValue[key], partial[key]);
+        } else {
+            previous[key] = currentValue[key];
+        }
+    });
+    return previous;
+}
+exports.previously = previously;
 
 exports.cloneObject = function (source) {
     return JSON.parse(JSON.stringify(source));

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -133,6 +133,7 @@ describe "StoreIt!", ->
         describe "when calling set", ->
             beforeEach ->
                 @value = {foo: "foo"}
+                @value2 = {foo: "bar"}
                 @publishAdded = sinon.stub()
                 service.on("added", @publishAdded)
 
@@ -140,14 +141,14 @@ describe "StoreIt!", ->
                 service.on("modified", @publishModified)
 
                 @result = service.set("testkey1", @value)
-                @result2 = service.set("testkey1", "other")
-                @result3 = service.set("testkey1", "other")
+                @result2 = service.set("testkey1", @value2)
+                @result3 = service.set("testkey1", @value2)
 
             afterEach ->
                 service.off("added", @publishAdded)
                 service.off("modified", @publishModified)
 
-            it "should call storageProvider.setItem with the object", ->
+            it "hold call storageProvider.setItem with the object", ->
                 @storageProvider.setItem.should.be.calledWith("testns:testkey1", @value)
             it "should publish a 'added' event", ->
                 @publishAdded.should.have.been.called
@@ -157,6 +158,12 @@ describe "StoreIt!", ->
                 spyCall.args[0].should.not.equal(@value)
             it "should publish a 'modified' event (if key exists)", ->
                 @publishModified.should.have.been.called
+            it "should publish a 'modified' event (if key exists) with the proper arguments", ->
+                spyCall = @publishModified.getCall(0)
+                JSON.stringify(spyCall.args[0]).should.equal(JSON.stringify(@value2))
+                spyCall.args[1].should.equal("testkey1")
+                JSON.stringify(spyCall.args[2]).should.equal(JSON.stringify(@value))
+                spyCall.args[0].should.not.equal(@value)
             it "should NOT publish (if key exists and value is unchanged)", ->
                 @publishModified.should.have.been.calledOnce
 


### PR DESCRIPTION
Add a third parameter when publishing a `modified` event that represents the old/previous value or `previousPartial`.