### PR TITLE
Add a `ready` event

### DIFF
--- a/lib/Storeit.js
+++ b/lib/Storeit.js
@@ -20,7 +20,7 @@ var mixins = [
 
 var NS_SEPARATOR_CHAR = "#";
 
-var events = ["added", "modified", "removed", "cleared"];
+var events = ["added", "modified", "removed", "cleared", "ready"];
 var EventName = _.object(events, events);
 
 function throwUninitializedError() {
@@ -55,6 +55,18 @@ function Storeit(namespace, storageProvider) {
     var originalPublish = publish;
 
     var throwIfUninitialized = throwUninitializedError; // Default until `load` is called.
+
+    function isInitialized() {
+        return throwIfUninitialized !== throwUninitializedError;
+    }
+
+    function initialize() {
+        var needsInitialization = !isInitialized();
+        if (needsInitialization) {
+            throwIfUninitialized = _.noop; // Allow other methods to work without throwing.
+        }
+        return needsInitialization;
+    }
 
     function addEvent(eventName) {
         if (!Storeit.EventName[eventName]) {
@@ -206,7 +218,7 @@ function Storeit(namespace, storageProvider) {
 
     // Here are a few built-in methods and properties.
     that.clear = function () {
-        throwIfUninitialized = _.noop; // Allow other methods to work without throwing.
+        var publishReady = initialize(); // Initialize only if needed and return true if initalization was performed.
         getIndex().forEach(function (key) { // Remove everything from provider, loaded or not.
             storageProvider.removeItem(nskey(key));
             storageProvider.removeItem(mkey(key));
@@ -216,6 +228,9 @@ function Storeit(namespace, storageProvider) {
         storageProvider.removeItem(ikey("primary"));
         storageProvider.removeItem(namespace); // Remove the storageMetadata for the namespace.
         publish(EventName.cleared);
+        if (publishReady) {
+            publish(EventName.ready);
+        }
     };
 
     Object.defineProperty(that, "options", {
@@ -231,9 +246,7 @@ function Storeit(namespace, storageProvider) {
     });
 
     Object.defineProperty(that, "isInitialized", {
-        get: function () {
-            return throwIfUninitialized !== throwUninitializedError;
-        },
+        get: isInitialized,
         enumerable: true
     });
 
@@ -250,6 +263,7 @@ function Storeit(namespace, storageProvider) {
             var value = storageProvider.getItem(nskey(key));
             setCache(key, value); // Build cache and publish an "added" events.
         });
+        publish(EventName.ready);
     };
 
     // Expose these internal functions to the mixins.

--- a/lib/Storeit.js
+++ b/lib/Storeit.js
@@ -229,7 +229,7 @@ function Storeit(namespace, storageProvider) {
         storageProvider.removeItem(namespace); // Remove the storageMetadata for the namespace.
         publish(EventName.cleared);
         if (publishReady) {
-            publish(EventName.ready);
+            originalPublish(EventName.ready);
         }
     };
 
@@ -263,7 +263,7 @@ function Storeit(namespace, storageProvider) {
             var value = storageProvider.getItem(nskey(key));
             setCache(key, value); // Build cache and publish an "added" events.
         });
-        publish(EventName.ready);
+        originalPublish(EventName.ready); // Publish even if options.publish is false.
     };
 
     // Expose these internal functions to the mixins.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storeit",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A key/value storage system that publishes events.",
   "main": "./lib/Storeit.js",
   "homepage": "https://github.com/YuzuJS/storeit",

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -397,10 +397,15 @@ describe "StoreIt!", ->
 
         describe "when calling clear", ->
             beforeEach ->
+                @publishReady = sinon.stub()
+                service.on("ready", @publishReady)
                 service.set("testkey1", 1)
                 service.set("testkey2", 2)
                 service.set("testkey3", 3)
                 service.clear()
+
+            afterEach ->
+                service.off("ready", @publishReady)
 
             it "should call storageProvider.getItem for the index", ->
                 spyCall = @getMetadata.getCall(0)
@@ -422,6 +427,9 @@ describe "StoreIt!", ->
             it "should result in an empty array for keys", ->
                 @keys = service.keys
                 @keys.length.should.equal(0)
+
+            it "should NOT publish a 'ready' event", ->
+                @publishReady.should.not.have.been.called
 
 
     describe "with one item of pre-loaded data", ->
@@ -488,11 +496,29 @@ describe "StoreIt!", ->
             ).should.throw(StoreitError)
 
         describe "then once we call load()", ->
-            it "should have `isInitialized` set to true", ->
+            beforeEach ->
+                @publishReady = sinon.stub()
+                service.on("ready", @publishReady)
                 service.load()
+
+            afterEach ->
+                service.off("ready", @publishReady)
+
+            it "should have `isInitialized` set to true", ->
                 service.isInitialized.should.equal(true)
+            it "should publish a 'ready' event", ->
+                @publishReady.should.have.been.called
 
         describe "then once we call clear()", ->
-            it "should have `isInitialized` set to true", ->
+            beforeEach ->
+                @publishReady = sinon.stub()
+                service.on("ready", @publishReady)
                 service.clear()
+
+            afterEach ->
+                service.off("ready", @publishReady)
+
+            it "should have `isInitialized` set to true", ->
                 service.isInitialized.should.equal(true)
+            it "should publish a 'ready' event", ->
+                @publishReady.should.have.been.called


### PR DESCRIPTION
Add a new `ready` event that is published when the store data is ready for use (i.e. when first `load`ed or `clear`ed).