### PR TITLE
Clone values before storing them into the cache.

### DIFF
--- a/lib/Storeit.js
+++ b/lib/Storeit.js
@@ -157,7 +157,7 @@ function Storeit(namespace, storageProvider) {
             }
         } else {
             cache[key] = {
-                value: value,
+                value: cloneObject(value),
                 metadata: null
             };
             publish(EventName.added, cloneObject(value), key);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storeit",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A key/value storage system that publishes events.",
   "main": "./lib/Storeit.js",
   "homepage": "https://github.com/YuzuJS/storeit",

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -109,6 +109,18 @@ describe "StoreIt!", ->
             ).should.throw(StoreitError)
 #            ).should.throw(new StoreitError(StoreitError.nonexistentKey))
 
+        describe "calling set then modify the stored object", ->
+            beforeEach ->
+                @value = {foo: "foo"}
+                service.set("key1", @value)
+
+                @value.moo = "New property added"
+                @retrievedValue = service.get("key1")
+
+            it "should not modify the stored object", ->
+                @retrievedValue.should.not.have.property("moo")
+
+
         describe "when calling has", ->
 
             it "on a valid key... should return true", ->


### PR DESCRIPTION
This fixes an issue where if we don't clone the object before storing it, and we change this object somewhere else, the change ends up propagating to the stored object in session storage.