### PR TITLE
Set with specifying Key

### DIFF
--- a/lib/Storeit.js
+++ b/lib/Storeit.js
@@ -170,6 +170,11 @@ function Storeit(namespace, storageProvider) {
     }
 
     function setValue(key, value, metadata) {
+        if (typeof key !== "string" && isObject(key)) {
+            metadata = value;
+            value = key;
+            key = value[options.primaryKey];
+        }
         throwIfUndefined(value);
         var results = setCache(key, value, metadata);
         if (results.action === Action.added) {

--- a/lib/Storeit.js
+++ b/lib/Storeit.js
@@ -48,7 +48,8 @@ function Storeit(namespace, storageProvider) {
 
     var options = { // Defaut options.
         publish: true,
-        publishRemoveOnClear: false
+        publishRemoveOnClear: false,
+        primaryKey: "id"
     };
 
     var publish = pubit.makeEmitter(that, events); // Mixin `on`, `off`, `once`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storeit",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A key/value storage system that publishes events.",
   "main": "./lib/Storeit.js",
   "homepage": "https://github.com/YuzuJS/storeit",


### PR DESCRIPTION
I've noticed a pattern amongst the legions of Storeit developers out there. When using `set` they extract the key from the object itself... every time.

Example:
```js
store.set(data.id, data)
```

Wouldn't it be easier if Storeit just knew to use `data.id`? Well now it does. There is now a new `option` called `primaryKey` (default = "id"). This represents the primary key of the "table". Then when calling `set`, you can now simply do the following:

```js
store.set(data)
```

If your primary key is not "id", then set the options as follows:
```js
store.options = { primaryKey: "foo" };
```

Internally, Storeit extracts the key and everything else remains the same.